### PR TITLE
Holodex button improvements part 3

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -19,6 +19,7 @@ const content_scripts = [
 ];
 
 const web_accessible_resources = [
+  "content/yt-watch.inject.js",
   "content/yt-player-overrides.inject.js",
   "content/yt-chat-overrides.inject.js",
   "content/yt-chat-tlsync.inject.js",

--- a/src/content/yt-watch.inject.ts
+++ b/src/content/yt-watch.inject.ts
@@ -1,0 +1,51 @@
+const globals = window as any;
+
+// Broadcast page data for yt-watch's openHolodexUrl usage.
+function sendPageData(pageData: any, pageDataLabel: string) {
+  pageDataLabel += ":";
+  window.postMessage({ pageData, pageDataLabel }, window.location.origin);
+}
+
+// This YT custom event fires whenever page data is fetched,
+// including both new page (re)load and internal navigation to another page.
+// Note: This could be done in the content script context rather than page context,
+// but since the yt* global vars fallback requires page context to access,
+// might as well implement it here.
+let pageData: any = null;
+document.addEventListener("yt-page-data-fetched", (evt: any) => {
+  console.debug("[Holodex+] yt-page-data-fetched event.detail:", evt.detail);
+  pageData = evt.detail?.pageData;
+  if (!pageData) {
+    console.warn("[Holodex+] yt-page-data-fetched event.detail.pageData unexpectedly", pageData);
+    return;
+  }
+  sendPageData(pageData, "yt-page-data-fetched event.detail.pageData");
+});
+
+// Initialize page data from yt* global vars in case above event hasn't fired yet
+// by the time yt-watch's openHolodexUrl is received.
+function pageDataFromYtGlobals() {
+  const page = globals.ytPageType;
+  if (!page)
+    throw "[Holodex+] could not find global ytPageType";
+  const response = globals.ytInitialData;
+  if (!response)
+    throw "[Holodex+] could not find global ytInitialData";
+  const playerResponse = globals.ytInitialPlayerResponse;
+  return {
+    page,
+    response,
+    ...(playerResponse && {playerResponse}) // omit playerResponse if unavailable
+  };
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  console.debug("[Holodex+] DOMContentLoaded");
+  if (pageData) return;
+  pageData = pageDataFromYtGlobals();
+  sendPageData(pageData, "DOMContentLoaded yt* global vars");
+});
+
+console.log("[Holodex+] page script injected");
+
+export {};

--- a/src/content/yt-watch.ts
+++ b/src/content/yt-watch.ts
@@ -81,7 +81,13 @@ async function openUrl(url: string) {
     const ytdApp = document.querySelector("ytd-app");
     if (!ytdApp) throw new Error("[Holodex+] unexpectedly could not find ytd-app");
 
-    const actions = await waitForElementId("actions", ytdApp);
+    let actions;
+    try {
+      actions = await waitForElementId("actions", { root: ytdApp, timeout: 10000 });
+    } catch (e) {
+      console.debug("[Holodex+] could not find #actions after 10 secs");
+      return;
+    }
     console.debug("[Holodex+] found #actions:", actions);
 
     // Setup mutation observer to (re)render when #top-level-buttons-computed is added,
@@ -125,7 +131,7 @@ async function openUrl(url: string) {
   async function findCanonicalUrl() {
     if (!pageData) {
       console.debug("[Holodex+] waiting for page data to become available...");
-      await pageDataSignal.wait(1000);
+      await pageDataSignal.wait(3000);
       if (!pageData) {
         console.log("[Holodex+] page data still unavailable - will default to fetch fallback to find canonical URL");
         return null;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -5,9 +5,9 @@ export const HOLODEX_URL_REGEX = /^(?:[^:]+:\/\/)?(?:[^\/]+\.)?holodex.net\b/i;
 // This needs to match the YouTube URL matching in generate-manifest.js.
 export const YOUTUBE_URL_REGEX = /^(?:[^:]+:\/\/)?(?:[^\/]+\.)?youtube.com\b/i;
 
-export const CHANNEL_URL_REGEX = /\b[A-Za-z0-9\-_]{24}\b/;
+export const CHANNEL_URL_REGEX = /(?<=[=\/?&#])[A-Za-z0-9\-_]{24}(?=[=\/?&#]|$)/;
 
-export const VIDEO_URL_REGEX = /\b[A-Za-z0-9\-_]{11}\b/;
+export const VIDEO_URL_REGEX = /(?<=[=\/?&#])[A-Za-z0-9\-_]{11}(?=[=\/?&#]|$)/;
 
 export const CANONICAL_URL_REGEX = /\/(?:channel\/[A-Za-z0-9\-_]{24}|(?:shorts\/|watch\?v=)[A-Za-z0-9\-_]{11})\b/;
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -3,7 +3,9 @@ import { runtime } from "webextension-polyfill";
 const HOLODEX_URL_REGEX = /^(?:[^:]+:\/\/)?(?:[^\/]+\.)?holodex.net\b/i;
 
 // This needs to match the YouTube URL matching in generate-manifest.js.
-const YOUTUBE_URL_REGEX = /^(?:[^:]+:\/\/)?(?:[^\/]+\.)?youtube.com\b/i;
+const YOUTUBE_HOSTNAME_REGEX = /^(?:[^\/]+\.)?youtube.com/i;
+
+const FEED_PATHNAME_REGEX = /^(?:\/?$|\/feed\b)/i; // pathname matches homepage or any feed like subscriptions
 
 const CHANNEL_URL_REGEX = /(?<=[=\/?&#])[A-Za-z0-9\-_]{24}(?=[=\/?&#]|$)/;
 
@@ -32,7 +34,8 @@ export async function getHolodexUrl(url: string | undefined, findCanonicalUrl: (
     if (channelMatch) {
       return `https://holodex.net/channel/${channelMatch[0]}`;
     }
-    if (YOUTUBE_URL_REGEX.test(url)) {
+    const urlObj = new URL(url);
+    if (YOUTUBE_HOSTNAME_REGEX.test(urlObj.hostname) && !FEED_PATHNAME_REGEX.test(urlObj.pathname)) {
       const canonicalUrl = await findCanonicalUrl(url);
       if (canonicalUrl) {
         const videoMatch = canonicalUrl.match(VIDEO_URL_REGEX);


### PR DESCRIPTION
Followup to #19 and #20 

1. Fix regression where Holodex button wasn't matching channel/video ids beginning and/or ending in a dash (`-`)
2. Fix regression where `@handle` channels were being treated as channel/video ids if they had exactly 24 or 11, respectively, characters
3. Holodex button for YT homepage and feeds (e.g. subscription, history, library) go to Holodex homepage
4. Clicking Holodex button injected in watch page now ensures newly opened tab is focused (already happens when clicking the Holodex button extension icon)
5. Simplify/revamp Holodex button internals such that now a single message is sent from background to content script
6. More reliable access to yt* global vars fallback for page data (used for getting Holodex URL) via injected page script
7. Misc other minor chances to improve reliability and performance