### PR TITLE
Remove obsolete YT chat memory leak fix and the option for it

### DIFF
--- a/src/content/yt-chat-overrides.inject.ts
+++ b/src/content/yt-chat-overrides.inject.ts
@@ -1,65 +1,11 @@
-// https://greasyfork.org/en/scripts/422206-workaround-for-youtube-chat-memory-leaks/code
-
-// @ts-ignore
-const ytglobal = window.ytglobal;
-// @ts-ignore
-const ytcfg = window.ytcfg;
-
 // Fix theme not following query param on archive chat
-const params = new URLSearchParams(window.location.search);
-if(params.get("dark_theme") === "1") {
+const darkThemeParam = new URLSearchParams(window.location.search).get("dark_theme");
+if (darkThemeParam === "1") {
   document.querySelector("html")?.setAttribute("dark", "");
-}
-else if(params.get("dark_theme") === "0") {
+} else if (darkThemeParam === "0") {
   document.querySelector("html")?.removeAttribute("dark");
 }
 
-/*
- * Currently (2021-02-23), youtube live chat has a bug that never execute some scheduled tasks.
- * Those tasks are scheduled for each time a new message is added to the chat and hold the memory until being executed.
- * This script will let the scheduler to execute those tasks so the memory held by those tasks could be freed.
- */
-function fixSchedulerLeak() {
-  if (!window.requestAnimationFrame) {
-    console.warn("[Holodex+]", "fixSchedulerLeak: window.requestAnimationFrame() is required, but missing");
-    return;
-  }
-  const scheduler = ytglobal && ytglobal.schedulerInstanceInstance_;
-  if (!scheduler) {
-    console.warn("[Holodex+]", "fixSchedulerLeak: schedulerInstanceInstance_ is missing");
-    return;
-  }
-  const code = "" + scheduler.constructor;
-  const p1 = code.match(/this\.(\w+)\s*=\s*!!\w+\.useRaf/);
-  const p2 = code.match(/\(\"visibilitychange\",\s*this\.(\w+)\)/);
-  if (!p1 || !p2) {
-    console.warn("[Holodex+]", "fixSchedulerLeak: unknown code");
-    return;
-  }
-  const useRafProp = p1[1];
-  const visChgProp = p2[1];
-  if (scheduler[useRafProp]) {
-    console.info("[Holodex+]", "fixSchedulerLeak: no work needed");
-    return;
-  }
-  scheduler[useRafProp] = true;
-  document.addEventListener("visibilitychange", scheduler[visChgProp]);
-  console.info("[Holodex+]", "fixSchedulerLeak: leak fixed");
-}
+console.log("[Holodex+] live chat overrides injected");
 
-/* Enable the element pool to save memory consumption. */
-function enableElementPool() {
-  if (!ytcfg) {
-    console.warn("[Holodex+]", "enableElementPool: ytcfg is missing");
-    return;
-  }
-  if (ytcfg.get("ELEMENT_POOL_DEFAULT_CAP")) {
-    console.info("[Holodex+]", "[Holodex+]", "enableElementPool: no work needed");
-    return;
-  }
-  ytcfg.set("ELEMENT_POOL_DEFAULT_CAP", 75);
-  console.info("[Holodex+]", "enableElementPool: element pool enabled");
-}
-
-fixSchedulerLeak();
-enableElementPool();
+export {};

--- a/src/content/yt-chat.ts
+++ b/src/content/yt-chat.ts
@@ -1,14 +1,10 @@
-import { inject, Options, validOrigin } from "../util";
+import { inject, validOrigin } from "../util";
 
-(async () => {
-  if (!(await Options.get("liveChatMemoryLeakFix"))) return;
-  console.log("[Holodex+] Injecting live chat memory leak fix");
-  inject("content/yt-chat-overrides.inject.js");
-})();
+inject("content/yt-chat-overrides.inject.js");
 
 // Re-emit events from wrong origins
 window.addEventListener("message", (event) => {
-  if(validOrigin(event.origin)) {
+  if (validOrigin(event.origin)) {
     window.postMessage(event.data, "*");
   }
-}, false);
+});

--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -3,7 +3,6 @@ import { storage } from "webextension-polyfill";
 // To add something to options, just add it to `schema`
 const schema = {
   // key: default-value
-  liveChatMemoryLeakFix: true,
   remoteLikeButton: true,
   openInHolodexButton: false,
   openHolodexInNewTab: true
@@ -11,8 +10,6 @@ const schema = {
 };
 type Schema = typeof schema;
 const descriptions: Partial<Record<keyof Schema, string>> = {
-  liveChatMemoryLeakFix:
-    "YouTube live chat has a bug where some scheduled tasks are never executed. This patches the scheduler to ensure the memory held by those tasks can be garbage collected.",
   openInHolodexButton:
     "Add a Open in Holodex button to Youtube"
 };


### PR DESCRIPTION
From https://greasyfork.org/en/scripts/422206-workaround-for-youtube-chat-memory-leaks-obsoleted:
> (2022-11-25) YouTube seems to have fixed the problem already. So this script is no longer needed.

It was sometimes resulting in erroneous `fixSchedulerLeak: unknown code` warnings.