### PR TITLE
Fix double Holodex tab opening regression in Firefox

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -90,11 +90,14 @@ async function openHolodexUrl(tab: Tabs.Tab) {
   try {
     const result = await tabs.sendMessage(tab.id!, { command: "openHolodexUrl" });
     if (result) {
-      // There's no 100% reliable way to get the tab id of a newly opened tab,
-      // so don't bother to try fetching that new tab, especially just for debug logging.
+      // There's no 100% reliable way to get the tab id of a newly opened tab created from content/page script,
+      // so don't bother to try fetching that new tab just for debug logging.
       console.debug(result.newTabOpened ? "new tab created" : "updated tab", "from content script:", result.url);
+    } else {
+      console.debug("no new/updated tab for:", tab.url);
     }
   } catch (e) {
+    console.debug("(fallback) due to:", e);
     fallbackOpenHolodexUrl(tab);
   }
 }
@@ -113,7 +116,10 @@ async function fallbackOpenHolodexUrl(tab: Tabs.Tab) {
     console.debug("(fallback) found canonical URL:", canonicalUrl);
     return canonicalUrl;
   });
-  if (!url) return;
+  if (!url) {
+    console.debug("(fallback) no new/updated tab for:", tab.url);
+    return;
+  }
   if (await Options.get("openHolodexInNewTab")) {
     const createProps: Tabs.CreateCreatePropertiesType = {
       url,

--- a/src/content/yt-watch.ts
+++ b/src/content/yt-watch.ts
@@ -49,7 +49,7 @@ async function openUrl(url: string) {
     const videoId = currentUrl.searchParams.get("v");
     // TODO: Holodex watch page doesn't actually support the t param yet...
     const t = currentUrl.searchParams.get("t");
-    openUrl(`https://holodex.net/watch/${videoId}${t ? `?t=${t}` : ""}`);
+    await openUrl(`https://holodex.net/watch/${videoId}${t ? `?t=${t}` : ""}`);
   }
 
   function render(target: Element, debugLabel: string) {
@@ -117,13 +117,15 @@ async function openUrl(url: string) {
   // and return a Promise only for the messages the listener is meant to respond to — and otherwise return false or undefined"
   runtime.onMessage.addListener((message) => {
     if (message?.command !== "openHolodexUrl") return;
+    console.debug("[Holodex+] handling openHolodexUrl message");
     return Promise.resolve(openHolodexUrl());
   });
 
   async function openHolodexUrl() {
     const url = await getHolodexUrl(window.location.href, findCanonicalUrl)
     if (!url) return null;
-    const newTabOpened = openUrl(url);
+    const newTabOpened = await openUrl(url);
+    console.debug("[Holodex+]", newTabOpened ? "new tab created:" : "updated tab:", url);
     return { url, newTabOpened };
   }
 


### PR DESCRIPTION
Fix double Holodex tab opening regression in Firefox.

This bug could've also affected Chromium but apparently only manifested in Firefox.
Also some more related debug logging.