### PR TITLE
feat: added "Open in Holodex" context menu for links in YouTube

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "holodex-plus",
   "description": "Holodex companion extension",
-  "version": "0.4",
+  "version": "0.5",
   "scripts": {
     "build": "rollup -c",
     "clean": "rimraf build dist",

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -29,7 +29,7 @@ const web_accessible_resources = [
 
 //const hosts = ["*://*.youtube.com/*", "*://*.holodex.net/*", "*://*.twitch.tv/*", "*://*.twitcasting.tv/*", "*://embed.nicovideo.jp/*","*://player.bilibili.com/*"];
 const hosts = ["*://*.youtube.com/*", "*://*.holodex.net/*"];
-const permissions = ["tabs", "storage", "webRequest", "webRequestBlocking", ...hosts];
+const permissions = ["tabs", "storage", "webRequest", "webRequestBlocking", "contextMenus", ...hosts];
 const name = "Holodex Plus";
 
 export default ({ icons }) =>

--- a/src/content/yt-watch.ts
+++ b/src/content/yt-watch.ts
@@ -129,11 +129,11 @@ async function openUrl(url: string) {
   runtime.onMessage.addListener((message) => {
     if (message?.command !== "openHolodexUrl") return;
     console.debug("[Holodex+] handling openHolodexUrl message");
-    return Promise.resolve(openHolodexUrl());
+    return Promise.resolve(openHolodexUrl(message?.link));
   });
 
-  async function openHolodexUrl() {
-    const url = await getHolodexUrl(window.location.href, findCanonicalUrl)
+  async function openHolodexUrl(link = window.location.href) {
+    const url = await getHolodexUrl(link, findCanonicalUrl);
     if (!url) return null;
     const newTabOpened = await openUrl(url);
     console.debug("[Holodex+]", newTabOpened ? "new tab created:" : "updated tab:", url);

--- a/src/util/storage.ts
+++ b/src/util/storage.ts
@@ -6,6 +6,7 @@ const schema = {
   remoteYoutubeLikeButton: true,
   holodexButtonInYoutube: false,
   openHolodexInNewTab: true,
+  openInHolodexContextMenu: false,
 };
 type Schema = typeof schema;
 const descriptions: Partial<Record<keyof Schema, string>> = {};


### PR DESCRIPTION
- Added the "Open in Holodex" context menu for links in YouTube
- Feature is hidden in Options. By default this feature of turned off. User needs to enable the "Open in Holodex context menu" option and restart browser
- Context menu will only show up after user enables it in options, and only if they're on Youtube, and the link they right click on has target href to YouTube channels, shorts, feeds, or videos
- Piggy-back off the logic for handling "openHolodexUrl".  Context menu emits an event, and the existing logic handles it
- Modified existing event handler logic to allow message to contain an optional "link" parameter to enable the new feature